### PR TITLE
Update Soroban SDK to Version 22.0.0-rc.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 edition = "2021"
 keywords = ["no_std", "wasm"]
-rust-version = "1.83"
+rust-version = "1.79"
 
 [dependencies]
 soroban-sdk = { version = "22.0.0-rc.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 edition = "2021"
 keywords = ["no_std", "wasm"]
-rust-version = "1.79"
+rust-version = "1.83"
 
 [dependencies]
-soroban-sdk = { version = "21.7.6" }
+soroban-sdk = { version = "22.0.0-rc.2.1" }


### PR DESCRIPTION
This PR updates the Soroban SDK dependency from version 21.7.6 to 22.0.0-rc.2.1.

Changes include:

	- Updated the Cargo.toml file to reflect the new SDK version.

The project has been successfully built and tested locally to ensure compatibility with the updated dependency.